### PR TITLE
make oggm-gmip3 compatible to oggm_v16

### DIFF
--- a/oggm_gmip3/funcs.py
+++ b/oggm_gmip3/funcs.py
@@ -12,11 +12,9 @@ from oggm import entity_task
 from oggm import utils, cfg
 from oggm.core.massbalance import (MultipleFlowlineMassBalance,
                                    ConstantMassBalance,
-                                   PastMassBalance,
                                    RandomMassBalance)
 
 from oggm.shop.gcm_climate import process_gcm_data
-
 from oggm.core.flowline import FileModel, flowline_model_run
 from oggm.exceptions import InvalidParamsError
 


### PR DESCRIPTION
Only `import PastMassBalance` needed to be removed to make the script compatible to OGGM v16. 